### PR TITLE
[explore ] templating can now reference query elements

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -340,8 +340,15 @@ class SqlaTable(Model, BaseDatasource):
             extras=None,
             columns=None):
         """Querying any sqla table from this common interface"""
+        template_kwargs = {
+            'from_dttm': from_dttm,
+            'groupby': groupby,
+            'metrics': metrics,
+            'row_limit': row_limit,
+            'to_dttm': to_dttm,
+        }
         template_processor = get_template_processor(
-            table=self, database=self.database)
+            table=self, database=self.database, **template_kwargs)
 
         # For backward compatibility
         if granularity not in self.dttm_cols:
@@ -430,7 +437,8 @@ class SqlaTable(Model, BaseDatasource):
 
         # Supporting arbitrary SQL statements in place of tables
         if self.sql:
-            tbl = TextAsFrom(sa.text(self.sql), []).alias('expr_qry')
+            from_sql = template_processor.process_template(self.sql)
+            tbl = TextAsFrom(sa.text(from_sql), []).alias('expr_qry')
 
         if not columns:
             qry = qry.group_by(*groupby_exprs)

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -553,6 +553,20 @@ class CoreTests(SupersetTestCase):
         rendered = tp.process_template(sql)
         self.assertEqual("SELECT '2017-01-01T00:00:00'", rendered)
 
+    def test_get_template_kwarg(self):
+        maindb = self.get_main_database(db.session)
+        s = "{{ foo }}"
+        tp = jinja_context.get_template_processor(database=maindb, foo='bar')
+        rendered = tp.process_template(s)
+        self.assertEqual("bar", rendered)
+
+    def test_template_kwarg(self):
+        maindb = self.get_main_database(db.session)
+        s = "{{ foo }}"
+        tp = jinja_context.get_template_processor(database=maindb)
+        rendered = tp.process_template(s, foo='bar')
+        self.assertEqual("bar", rendered)
+
     def test_templated_sql_json(self):
         self.login('admin')
         sql = "SELECT '{{ datetime(2017, 1, 1).isoformat() }}' as test"


### PR DESCRIPTION
@akhun needed to access from_dttm and to_dttm from the superset-view
layer (when a table is defined as SQL code).

Note that previous to this PR, templated queries going through the
"visualize flow" would break in the explore view. This PR fixes that as
well.