### PR TITLE
DRAFT: notes on supporting Malloy in Superset

### DIFF
--- a/superset/connectors/__init__.py
+++ b/superset/connectors/__init__.py
@@ -14,3 +14,21 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
+# NOTE: I wanted to mention this artifact from a previous era.
+# In the Superset early days (circa ~2016), Superset started as a data
+# exploration tool on `Druid` which joined the ASF later in its lifecycle.
+# Early in the history of the project, we modified it to support SQL-based database
+
+# Back in those days, the `connectors` abstraction in this folder has two
+# implementations:
+# - one for Druid that used JSON and "dimensional queries"
+# - one for SQLAlchemy that used SQL and "relational queries"
+
+# Since then, Druid learned to speak SQL and the SQLAlchemy connector
+# became the default connector for all databases.
+# We then removed the Druid connector and this is what's left of it.
+
+# It may makes sense to reconsider this decision and revisit the idea of a "Connector"
+# abstraction that could include a SQLAlchemy connector and a Malloy connector.
+# Eventually  could be used to support other semantic layers as well.

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -15,6 +15,36 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=too-many-lines
+
+"""
+This module contains the base classes and models for all datasets
+
+The ORM model definitions for Dataset / Columns / Metrics are all defined here, as
+well as methods dealing with retriving/syncing this stuff.
+
+When opening the dataset editor in the UI, the backend will use these models to populate
+the editor with the correct metadata.
+
+In many ways, it represents what Superset knows about the dataset, and how it
+can be queried, including things like:
+- secrets/creds to access the database
+- SQL/jinja in case of "virtual" datasets
+- list of columns in the dataset
+- metric-related expressions
+- calculated dimensions
+- pretty labels and long description
+- [as of recently] folder structure to organize metrics/dimensions
+- dataset-specific configuration around caching, permissions, ... (see the settings tab
+  in the dataset editor)
+
+On the method side:
+- hooks to get list-of-values to populate filter boxes
+- a way to run sql and get a dataframe back
+- methods to interogate the database for metadata and update the dataset config, ...
+- ...
+
+"""
+
 from __future__ import annotations
 
 import builtins

--- a/superset/db_engine_specs/malloy.py
+++ b/superset/db_engine_specs/malloy.py
@@ -1,0 +1,57 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+"""
+NOTE: this class could encapsulate all of the Malloy-specific stuff
+it requires having a dbapi-copatible connection and SQLAlchemy dialect
+both of which are pretty easy to implement / mock, we've created many for oddball
+databases in the past that don't have limited SQL support...
+-------
+the base class is in superset/db_engine_specs/base.py, and as it is today, it allows
+all sorts of hooks (methods, class-level props, ...) to be overridden and handle things
+in custom ways, stuff like
+- get_table_names
+- get_schema_names
+- get_columns
+- data fetching, low level cursor handling, ...
+- time-grain aggregate generation (think DATE_TRUNC)
+
+the general assumption is that we're dealing with a SQL-speaking database, but could
+be extended to support other types of engines (e.g. NoSQL, etc.), or just as a general
+placeholder for any routines that are Malloy-specific. This allows compartmentalizing
+all the Malloy-specific stuff in one place, and not having to write `if
+engine.name == "malloy"` everywhere in the codebase.
+
+note that the SQL generation logic lives elsewhere in the codebase (will try and
+give some pointers to that later), and is not part of this class. But we
+could add things in the codebase that would allow us to say something like
+```python
+if not database.db_engine_spec.engine.supports_sql:
+    database.db_engine_spec.fetch_data_without_using_sql(dimensional_query_definition)
+else:
+    # follow current code path ...
+
+```
+"""
+
+from superset.db_engine_specs.base import BaseEngineSpec
+
+
+class MalloyEngineSpec(BaseEngineSpec):
+    engine = "mallow"
+    engine_name = "Malloy"

--- a/superset/db_engine_specs/malloy.py
+++ b/superset/db_engine_specs/malloy.py
@@ -20,7 +20,7 @@
 NOTE: this class could encapsulate all of the Malloy-specific stuff
 it requires having a dbapi-copatible connection and SQLAlchemy dialect
 both of which are pretty easy to implement / mock, we've created many for oddball
-databases in the past that don't have limited SQL support...
+databases in the past that have limited SQL support...
 -------
 the base class is in superset/db_engine_specs/base.py, and as it is today, it allows
 all sorts of hooks (methods, class-level props, ...) to be overridden and handle things
@@ -31,15 +31,15 @@ in custom ways, stuff like
 - data fetching, low level cursor handling, ...
 - time-grain aggregate generation (think DATE_TRUNC)
 
-the general assumption is that we're dealing with a SQL-speaking database, but could
-be extended to support other types of engines (e.g. NoSQL, etc.), or just as a general
-placeholder for any routines that are Malloy-specific. This allows compartmentalizing
-all the Malloy-specific stuff in one place, and not having to write `if
-engine.name == "malloy"` everywhere in the codebase.
+the general assumption here is that we're dealing with a SQL-speaking database, but
+could be extended to support other types of engines (e.g. NoSQL, etc.), or just as
+a general placeholder for any routines that are Malloy-specific. This allows
+compartmentalizing all the Malloy-specific stuff in one place, and not having
+to write `if engine.name == "malloy"` everywhere in the codebase.
 
 note that the SQL generation logic lives elsewhere in the codebase (will try and
 give some pointers to that later), and is not part of this class. But we
-could add things in the codebase that would allow us to say something like
+could add branching in the codebase that would allow us to say something like
 ```python
 if not database.db_engine_spec.engine.supports_sql:
     database.db_engine_spec.fetch_data_without_using_sql(dimensional_query_definition)
@@ -53,5 +53,5 @@ from superset.db_engine_specs.base import BaseEngineSpec
 
 
 class MalloyEngineSpec(BaseEngineSpec):
-    engine = "mallow"
+    engine = "malloy"
     engine_name = "Malloy"


### PR DESCRIPTION
This PR is opened as a stratchbook to provide some ideas/pointers around what a Superset / Malloy integration could look like.

In this PR you'll find a collection of pointers and notes, in-code, that highlight some of the areas that are most-relevant in-regards to an eventual integration of Malloy.

Goal is to works towards an hackathon-type approach that would help identify what needs to be done in order to properly support Malloy.

Eventually progress here and elsewhere will inform a Superset Improvement Proposal with the key findings from this process.

NOTE: from an information architecture standpoint, different approaches are possible. For the hacking/feasibility-study side, I think it makes sense to **bend** existing entities/objects to support malloy in this way:

- Think of "Database Connections" as a "Connections" and fill in the attributes of a "Malloy Connection" to connect to a "Malloy Publisher" instance, or a "GitHub-hosted" mallow project (?) or even an MS2-hosted construct (?)
- Think of the `Dataset` entity as a "Data Source", and create a new "Data Source" type for a "Malloy Project" right next to "Physical Dataset" and "Virtual Dataset". When picking a "Malloy Project", we'd interogate the connection to see which Project to use as a source. There's probably a need to "sync project" to fetch the metrics and dimensions as Superset assumes a local representation of metrics/dims. When syncing the project, we fetch and materialize the metadata locally, so that they can be represented in the same way as dimensions/metrics on our side
- Use and abuse the `superset/db_engine_specs` module as a way to gather all the malloy-specific logic outside the core codebase. We may need to refactor some things from the core codebase and onto that package

Potentially - and that would take more time/effort - it probably make sense to introduce new abstractions in the right places. More specifically formalizing the distinction between what's an actual "SQL Dataset" from a more proper "Semantic Layer" data source. This may require a fair amount of refactoring, formalizing a proper "Data Source" interface on top of both "SQL-datasets" and "Semantic Layer".

Ideating around abstractions, it could make sense to go towards this hierarchy of abstractions:

- **Datasource**: anything that can be used for data exploration, in essence exposes metrics/dimensions. Exposes metadata, can run dimensional queries and return dataframes, ...
  - **BaseSemanticLayer**: base to all semantic layer
    - **MalloySemanticLayer**: first/core implementation
    - **DbtSemanticLayer**: eventually could support this within this structure
    - **SqlMeshSemanticLayer**: same here, could support if/when it comes out
  - **Dataset**: current code logic for all SqlAlchemy-powered dataset, supports both physical and virtual datasets
  - **Other** types of datasources? Going off rails here but: GoogleAnalytics, MicroTragedy, Business Objects, anything that can expose metrics/dims and execute dimensional queries.

